### PR TITLE
Ensure UTF-8 JSON output

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,9 @@ lib_deps =
   ESP32Async/AsyncTCP
   ESP32Async/ESPAsyncWebServer
 monitor_speed = 115200
+
+[env:native]
+platform = native
+test_build_src = false
+build_flags = -Isrc -Itest/stubs
+

--- a/src/HeadlessWiFiSettings.cpp
+++ b/src/HeadlessWiFiSettings.cpp
@@ -12,6 +12,7 @@
 #include <limits.h>
 
 #include <vector>
+#include "json_utils.h"
 
 #define Sprintf(f, ...) ({ char* s; asprintf(&s, f, __VA_ARGS__); String r = s; free(s); r; })
 
@@ -31,29 +32,6 @@ namespace { // Helpers
         auto w = f.print(content);
         f.close();
         return w == content.length();
-    }
-
-    String json_encode(const String &raw) {
-        String r;
-        for (unsigned int i = 0; i < raw.length(); i++) {
-            char c = raw.charAt(i);
-            switch (c) {
-                case '\"': r += "\\\""; break;
-                case '\\': r += "\\\\"; break;
-                case '\b': r += "\\b"; break;
-                case '\f': r += "\\f"; break;
-                case '\n': r += "\\n"; break;
-                case '\r': r += "\\r"; break;
-                case '\t': r += "\\t"; break;
-                default:
-                    if (c < ' ' || c > '~') {
-                        r += Sprintf("\\u%04x", c);
-                    } else {
-                        r += c;
-                    }
-            }
-        }
-        return r;
     }
 
     enum class ParamType {
@@ -406,7 +384,7 @@ void HeadlessWiFiSettingsClass::httpSetup(bool wifi) {
             return;
         }
 
-        AsyncResponseStream *response = request->beginResponseStream("application/json");
+        AsyncResponseStream *response = request->beginResponseStream("application/json; charset=utf-8");
         response->print("[");
         bool needsComma = false;
         for (const auto& option : dropdown->options) {
@@ -424,7 +402,7 @@ void HeadlessWiFiSettingsClass::httpSetup(bool wifi) {
         Serial.println(path);
 
         int numNetworks = WiFi.scanNetworks();
-        AsyncResponseStream *response = request->beginResponseStream("application/json");
+        AsyncResponseStream *response = request->beginResponseStream("application/json; charset=utf-8");
         response->print("{\"networks\":{");
 
         bool needsComma = false;
@@ -503,7 +481,7 @@ void HeadlessWiFiSettingsClass::httpSetup(bool wifi) {
             return;
         }
 
-        AsyncResponseStream *response = request->beginResponseStream("application/json");
+        AsyncResponseStream *response = request->beginResponseStream("application/json; charset=utf-8");
         response->print("{");
 
         // Output current values

--- a/src/json_utils.h
+++ b/src/json_utils.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Arduino.h>
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+inline String json_encode(const String &raw) {
+    String r;
+    char buf[7];
+    for (unsigned int i = 0; i < raw.length(); i++) {
+        uint8_t c = raw[i];
+        switch (c) {
+            case '"': r += "\\\""; break;
+            case '\\': r += "\\\\"; break;
+            case '\b': r += "\\b"; break;
+            case '\f': r += "\\f"; break;
+            case '\n': r += "\\n"; break;
+            case '\r': r += "\\r"; break;
+            case '\t': r += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+                    r += buf;
+                } else {
+                    r += static_cast<char>(c);
+                }
+        }
+    }
+    return r;
+}
+} // namespace
+

--- a/test/stubs/Arduino.h
+++ b/test/stubs/Arduino.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <string>
+#include <cstdint>
+
+class String {
+    std::string data;
+public:
+    String() {}
+    String(const char* s): data(s ? s : "") {}
+    String(char c): data(1, c) {}
+    size_t length() const { return data.length(); }
+    bool isEmpty() const { return data.empty(); }
+    char operator[](size_t i) const { return data[i]; }
+    String& operator+=(const char* s) { data += s; return *this; }
+    String& operator+=(char c) { data.push_back(c); return *this; }
+    String& operator+=(const String& other) { data += other.data; return *this; }
+    const char* c_str() const { return data.c_str(); }
+};
+

--- a/test/test_json_encode/test_main.cpp
+++ b/test/test_json_encode/test_main.cpp
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+#include <unity.h>
+#include "json_utils.h"
+
+void test_utf8_preserved() {
+    String raw = "O’Reilly"; // O’Reilly with curly apostrophe
+    TEST_ASSERT_EQUAL_STRING("O’Reilly", json_encode(raw).c_str());
+}
+
+void test_control_escaped() {
+    String raw = "line\nfeed";
+    TEST_ASSERT_EQUAL_STRING("line\\nfeed", json_encode(raw).c_str());
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_utf8_preserved);
+    RUN_TEST(test_control_escaped);
+    return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- extract UTF-8-safe `json_encode` helper
- add unit tests covering multibyte SSIDs and control characters
- configure native PlatformIO environment for tests

## Testing
- `pio test -e native`
- `npm test` *(fails: Missing script "test")*
- `pio --version`


------
https://chatgpt.com/codex/tasks/task_e_68ab42a94d64832491daf767296392a9